### PR TITLE
Set the Label to Be Assigned to the Container

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,4 +3,5 @@ MRuby::Gem::Specification.new('mruby-subaco') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Yuki Nakata'
   spec.add_dependency('mruby-file-stat', :github => 'ksss/mruby-file-stat')
+  spec.add_dependency('mruby-pack', :github => 'iij/mruby-pack')
 end

--- a/mrblib/mrb_subaco.rb
+++ b/mrblib/mrb_subaco.rb
@@ -5,6 +5,13 @@ class Subaco
   def deny_global_network
     set_global_network 0
   end
+  def label=(label)
+    @label = label.unpack("H*")[0].hex
+    set_label @label
+  end
+  def label
+    @label
+  end
 end
 
 module Util


### PR DESCRIPTION
The configured labels are retained by Subaco for each NIC used by each container. 
These labels are used to control inter-container communication.